### PR TITLE
vec: handle `nil` values in varargs (ctor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ single lua table `tbl` (or several arguments) is (are) passed at
 construction, the vector will be filled with the lua table contents (or the
 given arguments).
 
-If provided, `tbl` must contain only contiguous number keys starting at 1.
+If provided, `tbl` must contain only contiguous number keys starting at 1 and no holes.
 Tables inside the `tbl` (or passed as arguments) will also be converted
 (recursively) to [tds.Vec](#tds.Vec) (if they contain only contiguous
-number keys starting from 1) or [tds.Hash](#tds.Hash) otherwise.
+number keys starting from 1 and no holes) or [tds.Hash](#tds.Hash) otherwise.
 
 A vector can contain any element (as value) supported by `tds`, as well as
 the `nil` value.

--- a/vec.lua
+++ b/vec.lua
@@ -111,9 +111,10 @@ local function isvec(tbl)
    return n == #tbl
 end
 
-local function fill(self, tbl)
-   assert(isvec(tbl), 'lua table with number keys (1...N) expected')
-   for key, val in ipairs(tbl) do
+local function fill(self, tbl, force)
+   assert(force or isvec(tbl), 'lua table with number keys (1...N) expected')
+   for key=1,(tbl.n or #tbl) do
+      local val = tbl[key]
       if type(val) == 'table' then
          if isvec(val) then
             self[key] = tds.Vec(val)
@@ -136,7 +137,7 @@ function vec:__new(...) -- beware of the :
    if select('#', ...) == 1 and type(select(1, ...)) == 'table' then
       fill(self, select(1, ...))
    elseif select('#', ...) > 0 then
-      fill(self, {...})
+      fill(self, table.pack(...), true)
    end
    return self
 end


### PR DESCRIPTION
It was the case before commit 65cce40.

This fixes #8 (otherwise we can as well reject this PR and fix the README to deprecate such usage).

I also tweaked the README to pinpoint that holes in tables are NOT supported, e.g.:

```Lua
tds.Vec{10, 20, nil 40} -- ko
tds.Vec(10, 20, {"foo", nil, "bar", "baz"}) -- ok but the inner table...
                                            -- is represented as a tds.Hash
```
